### PR TITLE
Fix building with clang

### DIFF
--- a/Source/ContentLib/Private/BPFContentLib.cpp
+++ b/Source/ContentLib/Private/BPFContentLib.cpp
@@ -250,7 +250,7 @@ bool UBPFContentLib::SetStringArrayFieldWithLog(TArray<FString>& Field, FString 
 		UE_LOG(LogContentLib, Error, TEXT("Field %s is not of Type Array"), *FieldName);
 		return false;
 	}
-	for (const auto i : Result->TryGetField(FieldName)->AsArray()) {
+	for (const auto& i : Result->TryGetField(FieldName)->AsArray()) {
 		if (i->Type == EJson::String) {
 			FString Item = i->AsString();
 			if (Item != "") {

--- a/Source/ContentLib/Private/CLCDOBPFLib.cpp
+++ b/Source/ContentLib/Private/CLCDOBPFLib.cpp
@@ -3,7 +3,7 @@
 
 #include "CLCDOBPFLib.h"
 #include "BPFContentLib.h"
-#include "Contentlib.h"
+#include "ContentLib.h"
 #include "Reflection/ReflectionHelper.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
@@ -320,13 +320,12 @@ void UCLCDOBPFLib::EditCDO(FProperty * Prop, TSharedPtr<FJsonValue> json,bool Do
 	else if (FStructProperty* SProp = CastField<FStructProperty>(Prop)) {
 		if (json->Type == EJson::Object)
 		{
-			for (auto prop = TFieldIterator<FProperty>(SProp->Struct); prop; ++prop) {
-				FProperty* Prop = *prop;
-				FString FieldName = Prop->GetName();
+			for (FProperty* NProp : TFieldRange<FProperty>(SProp->Struct)) {
+				FString FieldName = NProp->GetName();
 				if (json->AsObject()->HasField(FieldName))
 				{
 					TSharedPtr<FJsonValue> Jval = *json->AsObject()->Values.Find(FieldName);
-					EditCDO(Prop, Jval, DoLog, Ptr);
+					EditCDO(NProp, Jval, DoLog, Ptr);
 				}
 			}
 		}

--- a/Source/ContentLib/Private/CLCategoryBPFLib.cpp
+++ b/Source/ContentLib/Private/CLCategoryBPFLib.cpp
@@ -21,7 +21,7 @@ FString UCLCategoryBPFLib::GenerateFromItemCategory(TSubclassOf<UFGItemCategory>
 	Obj->Values.Add("Name",Name);
 	Obj->Values.Add("MenuPriority", MenuPriority);
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(Obj, JsonWriter);
 	return Write;
 }
@@ -70,7 +70,7 @@ FString UCLCategoryBPFLib::GenerateFromSchematicCategory(TSubclassOf<UFGSchemati
 	Obj->Values.Add("Name",Name);
 	Obj->Values.Add("Icon", Icon);
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(Obj, JsonWriter);
 	return Write;
 }

--- a/Source/ContentLib/Private/CLItemBPFLib.cpp
+++ b/Source/ContentLib/Private/CLItemBPFLib.cpp
@@ -4,7 +4,7 @@
 #include "CLItemBPFLib.h"
 #include "BPFContentLib.h"
 #include "FGWorldSettings.h"
-#include "Contentlib.h"
+#include "ContentLib.h"
 #include "Serialization/JsonSerializer.h"
 
 
@@ -315,8 +315,8 @@ FString UCLItemBPFLib::GenerateStringFromCLItem(FContentLib_Item Item)
 	}
 
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<
-		wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<
+		TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(Obj, JsonWriter);
 	return Write;
 }
@@ -463,8 +463,8 @@ FString UCLItemBPFLib::GenerateFromDescriptorClass(TSubclassOf<UFGItemDescriptor
 	}
 
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<
-		wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<
+		TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(Obj, JsonWriter);
 	return Write;
 }
@@ -617,8 +617,8 @@ FString UCLItemBPFLib::GenerateKitFromClass(TSubclassOf<UFGItemDescriptor> Item)
 	return "";
 
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<
-        wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<
+		TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(FContentLib_VisualKit::GetAsJsonObject(Item), JsonWriter);
 	return Write;
 
@@ -656,7 +656,7 @@ FString UCLItemBPFLib::GetVisualKitAsString(FContentLib_VisualKit Kit)
 	Obj->Values.Add("FluidColor", MakeShared<FJsonValueObject>(Color));
 	Obj->Values.Add("GasColor", MakeShared<FJsonValueObject>(ColorGas));
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(Obj, JsonWriter);
 	return Write;
 }
@@ -802,8 +802,8 @@ FString UCLItemBPFLib::GenerateFromNuclearFuelClass(TSubclassOf<UFGItemDescripto
 	{
 		TSubclassOf<UFGItemDescriptorNuclearFuel> Resource = *Item;
 		FString Write;
-		const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<
-            wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+		const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<
+			TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 		FJsonSerializer::Serialize(FContentLib_NuclearFuelItem::GetNuclearFuelAsJsonObject(Resource), JsonWriter);
 		return Write;
 	}
@@ -823,8 +823,8 @@ FString UCLItemBPFLib::GenerateResourceFromClass(TSubclassOf<UFGItemDescriptor> 
 	{
 		TSubclassOf<UFGResourceDescriptor> Resource = *Item;
 		FString Write;
-		const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<
-            wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+		const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<
+			TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 		FJsonSerializer::Serialize(FContentLib_ResourceItem::GetResourceAsJsonObject(Resource), JsonWriter);
 		return Write;
 	}

--- a/Source/ContentLib/Private/CLRecipeBPFLib.cpp
+++ b/Source/ContentLib/Private/CLRecipeBPFLib.cpp
@@ -70,7 +70,7 @@ void UCLRecipeBPFLib::AddBuilders(const TSubclassOf<class UFGRecipe> Recipe,FCon
 	if (ClearFirst)
 		Recipe.GetDefaultObject()->mProducedIn.Empty();
 
-	for(auto i : RecipeStruct.BuildIn) {
+	for(auto& i : RecipeStruct.BuildIn) {
 
 		if(i.Contains("/")) {
 			UClass* Loaded = LoadObject<UClass>(nullptr, *RecipeStruct.Category);
@@ -122,7 +122,7 @@ void UCLRecipeBPFLib::AddToSchematicUnlock(const TSubclassOf<class UFGRecipe> Re
 	if (!Recipe) {
 		return;
 	}
-	for (const FString SchematicToFind : RecipeStruct.UnlockedBy) {
+	for (const FString& SchematicToFind : RecipeStruct.UnlockedBy) {
 		UClass * SchematicClass = UBPFContentLib::FindClassWithLog(SchematicToFind,UFGSchematic::StaticClass(),Subsystem);
 		if (SchematicClass) {
 			UBPFContentLib::AddRecipeToUnlock(SchematicClass, Subsystem, Recipe);
@@ -195,19 +195,19 @@ FString UCLRecipeBPFLib::SerializeRecipe(const TSubclassOf<UFGRecipe> Recipe)
 	TArray< TSharedPtr<FJsonValue>> Ingredients;
 	TArray< TSharedPtr<FJsonValue>> Products;
 	TArray< TSharedPtr<FJsonValue>> ProducedIn; 
-	for(auto i : CDO->mIngredients) {
+	for(auto& i : CDO->mIngredients) {
 		auto IngObj = MakeShared<FJsonObject>();
 		IngObj->Values.Add("Item",MakeShared<FJsonValueString>(i.ItemClass->GetName()));
 		IngObj->Values.Add("Amount",MakeShared<FJsonValueNumber>(i.Amount));
 		Ingredients.Add(MakeShared<FJsonValueObject>(IngObj));
 	}
-	for(auto i : CDO->mProduct) {
+	for(auto& i : CDO->mProduct) {
 		auto IngObj = MakeShared<FJsonObject>();
 		IngObj->Values.Add("Item",MakeShared<FJsonValueString>(i.ItemClass->GetName()));
 		IngObj->Values.Add("Amount",MakeShared<FJsonValueNumber>(i.Amount));
 		Products.Add(MakeShared<FJsonValueObject>(IngObj));
 	}
-	for(auto i : CDO->mProducedIn) {
+	for(auto& i : CDO->mProducedIn) {
 		auto IngObj = MakeShared<FJsonObject>();
 		ProducedIn.Add(MakeShared<FJsonValueString>(i->GetPathName()));
 	}
@@ -225,7 +225,7 @@ FString UCLRecipeBPFLib::SerializeRecipe(const TSubclassOf<UFGRecipe> Recipe)
 	Obj->Values.Add("VariablePowerConsumptionFactor", mVariablePowerConsumptionFactor);
 	Obj->Values.Add("VariablePowerConsumptionConstant", mVariablePowerConsumptionConstant);
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(Obj, JsonWriter);
 	return Write;
 }
@@ -244,19 +244,19 @@ FString UCLRecipeBPFLib::SerializeCLRecipe(FContentLib_Recipe Recipe)
 	TArray< TSharedPtr<FJsonValue>> Ingredients;
 	TArray< TSharedPtr<FJsonValue>> Products;
 	TArray< TSharedPtr<FJsonValue>> ProducedIn; 
-	for(auto i : Recipe.Ingredients) {
+	for(auto& i : Recipe.Ingredients) {
 		auto IngObj = MakeShared<FJsonObject>();
 		IngObj->Values.Add("Item",MakeShared<FJsonValueString>(i.Key));
 		IngObj->Values.Add("Amount",MakeShared<FJsonValueNumber>(i.Value));
 		Ingredients.Add(MakeShared<FJsonValueObject>(IngObj));
 	}
-	for(auto i : Recipe.Products) {
+	for(auto& i : Recipe.Products) {
 		auto IngObj = MakeShared<FJsonObject>();
 		IngObj->Values.Add("Item",MakeShared<FJsonValueString>(i.Key));
 		IngObj->Values.Add("Amount",MakeShared<FJsonValueNumber>(i.Value));
 		Products.Add(MakeShared<FJsonValueObject>(IngObj));
 	}
-	for(auto i : Recipe.BuildIn) {
+	for(auto& i : Recipe.BuildIn) {
 		auto IngObj = MakeShared<FJsonObject>();
 		ProducedIn.Add(MakeShared<FJsonValueString>(i));
 	}
@@ -284,7 +284,7 @@ FString UCLRecipeBPFLib::SerializeCLRecipe(FContentLib_Recipe Recipe)
 	Obj->Values.Add("ClearBuilders", ClearBuilders);
 
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(Obj, JsonWriter);
 	return Write;
 };

--- a/Source/ContentLib/Private/CLSchematicBPFLib.cpp
+++ b/Source/ContentLib/Private/CLSchematicBPFLib.cpp
@@ -31,7 +31,7 @@ FContentLib_ResearchNode UCLSchematicBPFLib::GenerateResearchStructFromString(FS
 	UBPFContentLib::SetStringFieldWithLog(NodeStruct.ResearchTree, "ResearchTree", Result);
 
 
-	for (const auto i : Result->TryGetField("Parents")->AsArray()) {
+	for (const auto& i : Result->TryGetField("Parents")->AsArray()) {
 		if (i->Type == EJson::Object) {
 			if (i->AsObject()->HasField("X") && i->AsObject()->HasField("Y")) {
 				FContentLib_Vector2D Vector2D;
@@ -43,7 +43,7 @@ FContentLib_ResearchNode UCLSchematicBPFLib::GenerateResearchStructFromString(FS
 		}
 	}
 
-	for (const auto i : Result->TryGetField("Children")->AsArray()) {
+	for (const auto& i : Result->TryGetField("Children")->AsArray()) {
 		if (i->Type == EJson::Object) {
 			if (i->AsObject()->HasField("Child") && i->AsObject()->HasField("Roads")) {
 				FContentLib_ResearchNodeRoads Node;
@@ -90,7 +90,7 @@ FContentLib_ResearchNodeRoads UCLSchematicBPFLib::GenerateResearchNodeRoadsFromS
 	FContentLib_ResearchNodeRoads Roads;
 
 
-	for (const auto i : Result->TryGetField("Roads")->AsArray()) {
+	for (const auto& i : Result->TryGetField("Roads")->AsArray()) {
 		if (i->Type == EJson::Object) {
 			if (i->AsObject()->HasField("X") && i->AsObject()->HasField("Y")) {
 				FContentLib_Vector2D Vector2D;
@@ -210,7 +210,7 @@ FContentLib_Schematic UCLSchematicBPFLib::GenerateCLSchematicFromString(FString 
 				}
 			}
 			if (TResult->AsObject()->HasField("Parents") && TResult->AsObject()->TryGetField("Parents")->Type == EJson::Array) {
-				for (const auto i : TResult->AsObject()->TryGetField("Parents")->AsArray())
+				for (const auto& i : TResult->AsObject()->TryGetField("Parents")->AsArray())
 				{
 					if (i->Type == EJson::Object) {
 						if (i->AsObject()->HasField("X") && i->AsObject()->HasField("Y")) {
@@ -225,7 +225,7 @@ FContentLib_Schematic UCLSchematicBPFLib::GenerateCLSchematicFromString(FString 
 			}
 			if (TResult->AsObject()->HasField("UnHiddenBy") && TResult->AsObject()->TryGetField("UnHiddenBy")->Type == EJson::Array)
 			{
-				for (const auto i : TResult->AsObject()->TryGetField("UnHiddenBy")->AsArray()) {
+				for (const auto& i : TResult->AsObject()->TryGetField("UnHiddenBy")->AsArray()) {
 					if (i->Type == EJson::Object) {
 						if (i->AsObject()->HasField("X") && i->AsObject()->HasField("Y")) {
 							FContentLib_Vector2D Vector2D;
@@ -239,7 +239,7 @@ FContentLib_Schematic UCLSchematicBPFLib::GenerateCLSchematicFromString(FString 
 			}
 
 			if (TResult->AsObject()->HasField("NodesToUnHide") && TResult->AsObject()->TryGetField("NodesToUnHide")->Type == EJson::Array) {
-				for (const auto i : TResult->AsObject()->TryGetField("NodesToUnHide")->AsArray()) {
+				for (const auto& i : TResult->AsObject()->TryGetField("NodesToUnHide")->AsArray()) {
 					if (i->Type == EJson::Object) {
 						if (i->AsObject()->HasField("X") && i->AsObject()->HasField("Y")) {
 							FContentLib_Vector2D Vector2D;
@@ -252,7 +252,7 @@ FContentLib_Schematic UCLSchematicBPFLib::GenerateCLSchematicFromString(FString 
 				}
 			}
 			if (TResult->AsObject()->HasField("Children") && TResult->AsObject()->TryGetField("Children")->Type == EJson::Array) {
-				for (const auto i : TResult->AsObject()->TryGetField("Children")->AsArray()) {
+				for (const auto& i : TResult->AsObject()->TryGetField("Children")->AsArray()) {
 					if (i->Type == EJson::Object) {
 						if (i->AsObject()->HasField("ChildNode") && i->AsObject()->HasField("Roads")) {
 							FContentLib_Vector2D Key;
@@ -262,7 +262,7 @@ FContentLib_Schematic UCLSchematicBPFLib::GenerateCLSchematicFromString(FString 
 							}
 
 							TArray<FContentLib_Vector2D> Values;
-							for (const auto e : i->AsObject()->TryGetField("Roads")->AsArray()) {
+							for (const auto& e : i->AsObject()->TryGetField("Roads")->AsArray()) {
 								if (e->Type == EJson::Object) {
 									FContentLib_Vector2D Vector2D;
 									UBPFContentLib::SetIntegerFieldWithLog(Vector2D.X, "X", e->AsObject());
@@ -335,7 +335,7 @@ void UCLSchematicBPFLib::InitSchematicFromStruct(FContentLib_Schematic Schematic
 		CDO->mSubCategories.Empty();
 	}
 	if (Schematic.SubCategories.Num() > 0) {
-		for (const auto categoryString : Schematic.SubCategories) {
+		for (const auto& categoryString : Schematic.SubCategories) {
 			TSubclassOf<UFGSchematicCategory> Out = UBPFContentLib::SetCategoryWithLoad(categoryString, SubSystem, true);
 			if (Out) {
 				CDO->mSubCategories.Add(Out);
@@ -372,7 +372,7 @@ void UCLSchematicBPFLib::InitSchematicFromStruct(FContentLib_Schematic Schematic
 			}
 		}
 	}
-	for (const FString i : Schematic.Recipes) {
+	for (const FString& i : Schematic.Recipes) {
 		UClass* RecipesClass = UBPFContentLib::FindClassWithLog(i, UFGRecipe::StaticClass(), SubSystem);
 		if (RecipesClass) {
 			UBPFContentLib::AddRecipeToUnlock(SchematicClass, SubSystem, RecipesClass);
@@ -383,7 +383,7 @@ void UCLSchematicBPFLib::InitSchematicFromStruct(FContentLib_Schematic Schematic
 		UBPFContentLib::AddInfoOnlyToUnlock(SchematicClass, SubSystem, entry);
 	}
 
-	for (const FString i : Schematic.Schematics) { // TODO what sets this field?
+	for (const FString& i : Schematic.Schematics) { // TODO what sets this field?
 		UClass* Class = UBPFContentLib::FindClassWithLog(i, UFGSchematic::StaticClass(), SubSystem);
 		if (Class) {
 			UBPFContentLib::AddSchematicToUnlock(SchematicClass, SubSystem, Class);
@@ -405,7 +405,7 @@ void UCLSchematicBPFLib::InitSchematicFromStruct(FContentLib_Schematic Schematic
 	if (Schematic.ClearDeps) {
 		CDO->mSchematicDependencies.Empty();
 	}
-	for (const FString i : Schematic.DependsOn) {
+	for (const FString& i : Schematic.DependsOn) {
 		UClass* SchematicDep = UBPFContentLib::FindClassWithLog(i, UFGSchematic::StaticClass(), SubSystem);
 		if (SchematicDep && SchematicDep->IsChildOf(UFGSchematic::StaticClass())) {
 			UBPFContentLib::AddSchematicToPurchaseDep(SchematicClass, SubSystem, SchematicDep);
@@ -527,21 +527,21 @@ FString UCLSchematicBPFLib::SerializeSchematic(TSubclassOf<UFGSchematic> Schemat
 
 	TArray< TSharedPtr<FJsonValue>> Cost;
 	TArray< TSharedPtr<FJsonValue>> SubCats;
-	for (auto i : CDO->mCost) {
+	for (auto& i : CDO->mCost) {
 		auto IngObj = MakeShared<FJsonObject>();
 		IngObj->Values.Add("Item", MakeShared<FJsonValueString>(i.ItemClass->GetName()));
 		IngObj->Values.Add("Amount", MakeShared<FJsonValueNumber>(i.Amount));
 		Cost.Add(MakeShared<FJsonValueObject>(IngObj));
 	}
 
-	for (auto i : CDO->mSubCategories) {
+	for (auto& i : CDO->mSubCategories) {
 		auto IngObj = MakeShared<FJsonObject>();
 		SubCats.Add(MakeShared<FJsonValueString>(i->GetPathName()));
 	}
 	TArray< TSharedPtr<FJsonValue>> Recipes;
-	for (auto i : CDO->mUnlocks) {
+	for (auto& i : CDO->mUnlocks) {
 		if (Cast<UFGUnlockRecipe>(i)) {
-			for (auto e : Cast<UFGUnlockRecipe>(i)->mRecipes) {
+			for (auto& e : Cast<UFGUnlockRecipe>(i)->mRecipes) {
 				auto IngObj = MakeShared<FJsonObject>();
 				Recipes.Add(MakeShared<FJsonValueString>(e->GetPathName()));
 			}
@@ -554,7 +554,7 @@ FString UCLSchematicBPFLib::SerializeSchematic(TSubclassOf<UFGSchematic> Schemat
 
 	for (auto i : CDO->mSchematicDependencies) {
 		if (Cast<UFGSchematicPurchasedDependency>(i)) {
-			for (auto e : Cast<UFGSchematicPurchasedDependency>(i)->mSchematics) {
+			for (auto& e : Cast<UFGSchematicPurchasedDependency>(i)->mSchematics) {
 				auto IngObj = MakeShared<FJsonObject>();
 				Deps.Add(MakeShared<FJsonValueString>(e->GetPathName()));
 			}
@@ -580,7 +580,7 @@ FString UCLSchematicBPFLib::SerializeSchematic(TSubclassOf<UFGSchematic> Schemat
 	Obj->Values.Add("DependsOn", DepArray);
 
 	FString Write;
-	const TSharedRef<TJsonWriter<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>> JsonWriter = TJsonWriterFactory<wchar_t, TPrettyJsonPrintPolicy<wchar_t>>::Create(&Write); //Our Writer Factory
+	const TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> JsonWriter = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Write); //Our Writer Factory
 	FJsonSerializer::Serialize(Obj, JsonWriter);
 	return Write;
 }

--- a/Source/ContentLib/Private/CLUtilBPFLib.cpp
+++ b/Source/ContentLib/Private/CLUtilBPFLib.cpp
@@ -58,14 +58,14 @@ TMap<TSubclassOf<UFGItemDescriptor>, FFactoryGame_Descriptor>  UCLUtilBPFLib::Ca
 	TArray<TSubclassOf<UFGItemDescriptor>> RecipesItem;
 	RecurseIngredients(Item, RecipesItem, nRecipes, System, UseAlternates, Exclude);
 
-	for (auto i : RecipesItem) {
+	for (auto& i : RecipesItem) {
 		System->Items.Find(i)->MJValue = -1;
 	}
-	for (auto i : nRecipes) {
+	for (auto& i : nRecipes) {
 		System->Recipes.Find(i)->MJ.MJ_Average = 0;
 	}
 	CalculateCost(nRecipes,System);
-	for (auto i : RecipesItem) {
+	for (auto& i : RecipesItem) {
 		FFactoryGame_Descriptor& InValue = *System->Items.Find(i);
 		Map.Add(i, InValue);
 	}
@@ -78,7 +78,7 @@ void UCLUtilBPFLib::CalculateCost(TArray<TSubclassOf<UFGRecipe>> RecipesToCalc,U
 	int32 CounterInside = 0;
 	int8  Loops = 0;
 	while (CounterInside < RecipesToCalc.Num()) {
-		for (auto Recipe : RecipesToCalc) {
+		for (auto& Recipe : RecipesToCalc) {
 			FFactoryGame_Recipe& ItemItr = *System->Recipes.Find(Recipe);
 			if (ItemItr.MJ.TryAssignMJ(System))
 				CounterInside++;
@@ -95,13 +95,13 @@ void UCLUtilBPFLib::CalculateCost(TArray<TSubclassOf<UFGRecipe>> RecipesToCalc,U
 
 bool UCLUtilBPFLib::FindVisualKit(const FString Name, FContentLib_VisualKit& Kit,UContentLibSubsystem* System)
 {
-	for (const auto i : System->ImportedVisualKits) {
+	for (const auto& i : System->ImportedVisualKits) {
 		if (UBPFContentLib::StringCompareItem(Name,i.Key,"Desc","_C")) {
 			Kit = i.Value;
 			return true;
 		}
 	}
-	for (const auto i : System->VisualKits) {
+	for (const auto& i : System->VisualKits) {
 		if (UBPFContentLib::StringCompareItem(Name,i.Key,"Desc","_C")) {
 			Kit = i.Value;
 			return true;
@@ -116,7 +116,7 @@ void UCLUtilBPFLib::PrintSortedRecipes(UContentLibSubsystem* System)
 {
 	TArray<TSubclassOf<UObject>> Array_To_Sort_Keys;
 	TArray<float> Array_To_Sort_Values;
-	for(auto i: System->Recipes) {
+	for(auto& i: System->Recipes) {
 		if(i.Value.MJ.HasAssignedMJ()) {
 			Array_To_Sort_Keys.Add(i.Key);
 			Array_To_Sort_Values.Add(i.Value.MJ.MJ_Average);
@@ -132,7 +132,7 @@ void UCLUtilBPFLib::PrintSortedItems(UContentLibSubsystem* System)
 {
 	TArray<TSubclassOf<UObject>> Array_To_Sort_Keys;
 	TArray<float> Array_To_Sort_Values;
-	for(auto i: System->Items) {
+	for(auto& i: System->Items) {
 		if(i.Value.HasMj())
 		{
 			Array_To_Sort_Keys.Add(i.Key);
@@ -164,7 +164,7 @@ void UCLUtilBPFLib::RecurseIngredients(const TSubclassOf<class UFGItemDescriptor
 		return;
 	
 	const int32 Len = AllRecipes.Num(); 
-	for(auto i : System->Items.Find(Item)->ProductInRecipe) {
+	for(auto& i : System->Items.Find(Item)->ProductInRecipe) {
 		if(!Excluded.Contains(i))
 			continue;
 		if(!AllRecipes.Contains(i))
@@ -173,7 +173,7 @@ void UCLUtilBPFLib::RecurseIngredients(const TSubclassOf<class UFGItemDescriptor
 		if(Recipe.UnlockedFromAlternate() && SkipAlternate)
 			continue;
 		
-		for(auto e: Recipe.Ingredients()) {
+		for(auto& e: Recipe.Ingredients()) {
 			if(!AllRecipes.Contains(i))
 				RecurseIngredients(e, AllItems,AllRecipes,System, SkipAlternate,Excluded);
 			if(!AllItems.Contains(e))

--- a/Source/ContentLib/Private/ContentLibSubsystem.cpp
+++ b/Source/ContentLib/Private/ContentLibSubsystem.cpp
@@ -53,7 +53,7 @@ void UContentLibSubsystem::FillLoadedClasses()
 
 void UContentLibSubsystem::CollectVisualKits()
 {
-	for (const auto ItemPair : Items) {
+	for (const auto& ItemPair : Items) {
 		const auto key = ItemPair.Key;
 		if (!key) {
 			continue;
@@ -109,7 +109,7 @@ FFactoryGame_RecipeMJ::FFactoryGame_RecipeMJ(TSubclassOf<UFGRecipe> Outer): nRec
 int32 FFactoryGame_RecipeMJ::GetItemAmount(const TSubclassOf<UFGItemDescriptor> Item, bool Ingredient) {
 	TArray<TSubclassOf<class UFGItemDescriptor>> Out;
 	TArray<FItemAmount> Arr = Ingredient ? nRecipe.GetDefaultObject()->GetIngredients(): nRecipe.GetDefaultObject()->GetProducts();
-	for (auto i : Arr) {
+	for (auto& i : Arr) {
 		Out.Add(i.ItemClass);
 	}
 	if (!Out.Contains(Item)) {
@@ -124,7 +124,7 @@ bool FFactoryGame_RecipeMJ::CanCalculateMj(UContentLibSubsystem* System) const
 	if (!System || !nRecipe)
 		return false;
 	
-	for (auto i : UFGRecipe::GetIngredients(nRecipe)) {
+	for (auto& i : UFGRecipe::GetIngredients(nRecipe)) {
 		if (!System->Items.Find(i.ItemClass)->HasMj())
 			return false;
 	}
@@ -154,7 +154,7 @@ bool FFactoryGame_RecipeMJ::TryAssignMJ(UContentLibSubsystem* System)
 	FFactoryGame_Recipe & Recipe = *System->Recipes.Find(nRecipe);
 	const auto ingredients = UFGRecipe::GetIngredients(nRecipe);
 	float Sum = 0.f;
-	for (auto Ingredient : ingredients) {
+	for (auto& Ingredient : ingredients) {
 		System->Items.Find(Ingredient.ItemClass)->AssignAverageMj(System);
 		if (System->Items.Find(Ingredient.ItemClass)->HasMj()) {
 			Sum += System->Items.Find(Ingredient.ItemClass)->MJValue * Ingredient.Amount;
@@ -163,7 +163,7 @@ bool FFactoryGame_RecipeMJ::TryAssignMJ(UContentLibSubsystem* System)
 			return false;
 	}
 	Recipe.MJ.AddValue(Sum);
-	for (auto Product : Recipe.Products()) {
+	for (auto& Product : Recipe.Products()) {
 		System->Items.Find(Product)->AssignAverageMj(System);
 	}
 	return true;
@@ -174,7 +174,7 @@ float FFactoryGame_RecipeMJ::GetAverageBuildingCost(const TArray<TSubclassOf<UOb
 {
 	float CostSum = 0.f;
 	int32 CostSumDivider = 0;
-	for(auto & Producer: UFGRecipe::GetProducedIn(nRecipe)) {
+	for(auto& Producer: UFGRecipe::GetProducedIn(nRecipe)) {
 		if(Exclude.Contains(Producer))
 			continue;
 		FFactoryGame_ProductBuildingCost e = FFactoryGame_ProductBuildingCost(nRecipe,Producer);
@@ -203,7 +203,7 @@ float FFactoryGame_RecipeMJ::GetProductMjValue(TSubclassOf<UFGItemDescriptor> It
 	if(!Buildable) {
 		TArray<TSubclassOf<UObject>> Excludes;
 		if(ExcludeManual)
-			for(auto i : Producers)
+			for(auto& i : Producers)
 				if (i->IsChildOf(UFGWorkBench::StaticClass()) || i->IsChildOf(AFGBuildGun::StaticClass()))
 					Excludes.Add(i);
 	
@@ -339,7 +339,7 @@ float FFactoryGame_Descriptor::AssignAverageMj(UContentLibSubsystem* System, con
 	
 	float IngredientCost = 0.f;
 	int32 Count = 0;
-	for (auto Recipe : ProductInRecipe) {
+	for (auto& Recipe : ProductInRecipe) {
 		if(Exclude.Contains(Recipe))
 			continue;
 		
@@ -365,7 +365,7 @@ void UContentLibSubsystem::FullRecipeCalculation()
 	TArray<TSubclassOf<UFGRecipe>> BuildingRecipes;
 	TArray<TSubclassOf<UFGRecipe>> ManualOnly;
 
-	for(auto i : Recipes) {
+	for(auto& i : Recipes) {
 		if(i.Value.IsBuildGunRecipe())
 			BuildingRecipes.Add(i.Key);
 		else if(i.Value.IsManualOnly())
@@ -405,7 +405,7 @@ void UContentLibSubsystem::ClientInit()
 	TArray< FString> Paths;
 	UE_LOG(LogContentLib, Warning, TEXT("ContentLib loading relevant Mod Assets..."));
 	AssetRegistryModule.Get().GetSubPaths(TEXT("/"),Paths , false);
-	for (auto i : Paths) {
+	for (auto& i : Paths) {
 		if (!i.Equals("/Engine", ESearchCase::IgnoreCase)
 			&& !i.Equals("/Game", ESearchCase::IgnoreCase)
 			&& !i.Equals("/Wwise", ESearchCase::IgnoreCase)
@@ -421,7 +421,7 @@ void UContentLibSubsystem::ClientInit()
 			Filter.PackagePaths.Add(*i);
 			Filter.bIncludeOnlyOnDiskAssets = true;
 			AssetRegistryModule.Get().GetAssets(Filter, AssetsData);
-			for (auto asset : AssetsData) {
+			for (auto& asset : AssetsData) {
 				if (!asset.IsAssetLoaded()) {
 					FString NativeParentPath = *asset.TagsAndValues.FindTag("NativeParentClass").AsString();
 					UClass* Parent = FindObject<UClass>(NULL, *NativeParentPath);
@@ -432,7 +432,7 @@ void UContentLibSubsystem::ClientInit()
 					}
 					FString TempParentName = Parent->GetPathName();
 					UE_LOG(LogContentLibAssetParsing, VeryVerbose, TEXT("Parsing asset %s with parent %s"), *TempPackageName, *TempParentName);
-					auto assetPathString = asset.GetObjectPathString().Append("_C"); // TODOU8 Migrated asset.GetObjectPathString() from asset.ObjectPath.ToString()
+					auto& assetPathString = asset.GetObjectPathString().Append("_C"); // TODOU8 Migrated asset.GetObjectPathString() from asset.ObjectPath.ToString()
 					if (
 						   Parent->IsChildOf(UFGItemDescriptor::StaticClass()) 
 						|| Parent->IsChildOf(UFGSchematic::StaticClass()) 
@@ -456,7 +456,7 @@ void UContentLibSubsystem::ClientInit()
 								TArray<FCoreRedirect> Redirects;
 								Redirects.Add(FCoreRedirect(Flags, *asset.AssetName.ToString(), Obj->GetPathName()));
 								FCoreRedirects::AddRedirectList(Redirects,Obj->GetName());
-								auto * I = LoadObject<UClass>(NULL, *assetPathString);
+								auto* I = LoadObject<UClass>(NULL, *assetPathString);
 								if(I != Obj) {
 									UE_LOG(LogContentLib,Fatal,TEXT("Redirect Failed for %s"), *assetPathString);
 								}
@@ -493,11 +493,11 @@ void UContentLibSubsystem::ClientInit()
 			FString NativeParentPath = *asset.TagsAndValues.FindTag("NativeParentClass").AsString();
 			UClass* Parent = FindObject<UClass>(NULL, *NativeParentPath);
 			if (Parent &&
-				Parent->IsChildOf(UFGItemDescriptor::StaticClass())
+				(Parent->IsChildOf(UFGItemDescriptor::StaticClass())
 				|| Parent->IsChildOf(UFGSchematic::StaticClass())
 				|| Parent->IsChildOf(UFGResearchTree::StaticClass())
 				|| Parent->IsChildOf(UFGItemCategory::StaticClass())
-				|| Parent->IsChildOf(UFGRecipe::StaticClass())
+				|| Parent->IsChildOf(UFGRecipe::StaticClass()))
 				)
 			{
 				auto assetPathString = asset.GetObjectPathString().Append("_C"); // TODOU8 Migrated asset.GetObjectPathString() from asset.ObjectPath.ToString()


### PR DESCRIPTION
Most changes involve adding `&` after `auto` inside loops to avoid unintentionally making copies of elements in a for-each loop. Also replace the types used in JSON writer factories with `TCHAR` since these functions use `TCHAR` somewhere (and `TCHAR` is not equal to `wchar_t` on all platforms), ensure that `#include "ContentLib.h"` is spelled using the correct case, and fix a shadowed variable bug by renaming it.

Note: The rename around the shadowed variable also replaces the loop statement to make use of `TFieldRange<>`.

ONLY BUILD-TESTED.